### PR TITLE
Failed ito case

### DIFF
--- a/Exec/Examples/ItoKMC/StreamerIntegralCriterion/CD_ItoKMCBackgroundEvaluator.H
+++ b/Exec/Examples/ItoKMC/StreamerIntegralCriterion/CD_ItoKMCBackgroundEvaluator.H
@@ -48,7 +48,7 @@ namespace Physics {
 	@brief Post-checkpoint operations. Computes the background field.
       */
       virtual void
-      postCheckpointSetup() noexcept override final;      
+      postCheckpointSetup() noexcept override final;
 
       /*!
 	@brief Print a new step report. This is the old one plus the maximum field change.
@@ -56,11 +56,35 @@ namespace Physics {
       virtual void
       printStepReport() noexcept override final;
 
+      /*!
+	@brief Overriden advance method.
+	@param[in] a_dt Time step
+      */
+      virtual Real
+      advance(const Real a_dt) override;
+
+      /*!
+	@brief Compute a time step used for the advance method
+	@note This function returns a zero value if space charge effects have set in, which lets Driver put plot files in the crash folder.
+      */
+      virtual Real
+      computeDt() override;
+
     protected:
       /*!
 	@brief Exit criterion -- if the background field changes by this much the simulation is terminated.
       */
       Real m_exitCrit;
+
+      /*!
+	@brief Change in max field.
+      */
+      Real m_maxFieldChange;
+
+      /*!
+	@brief Change in relative field.
+      */
+      Real m_relFieldChange;
 
       /*!
 	@brief For storing the background field.
@@ -76,9 +100,10 @@ namespace Physics {
 
       /*!
 	@brief Evaluate the maximum change in the background field.
+	@return Returns a pair: relative change, maximum change
       */
       [[nodiscard]]
-      virtual Real
+      virtual std::pair<Real, Real>
       evaluateSpaceChargeEffects() noexcept;
     };
   } // namespace ItoKMC

--- a/Exec/Examples/ItoKMC/StreamerIntegralCriterion/CD_ItoKMCBackgroundEvaluatorImplem.H
+++ b/Exec/Examples/ItoKMC/StreamerIntegralCriterion/CD_ItoKMCBackgroundEvaluatorImplem.H
@@ -26,7 +26,9 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::ItoKMCBackgroundEvaluator(RefCountedPtr<I
 
   ParmParse pp("ItoKMCBackgroundEvaluator");
 
-  m_exitCrit = std::numeric_limits<Real>::max();
+  m_exitCrit       = std::numeric_limits<Real>::max();
+  m_maxFieldChange = -1.0;
+  m_relFieldChange = -1.0;
 
   pp.query("exit_crit", m_exitCrit);
 }
@@ -74,6 +76,55 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::postCheckpointSetup() noexcept
 }
 
 template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCBackgroundEvaluator<I, C, R, F>::advance(const Real a_dt)
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::advance");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::advance" << endl;
+  }
+
+  const Real actualDt = ItoKMCGodunovStepper<I, C, R, F>::advance(a_dt);
+
+  const std::pair<Real, Real> fieldChange = this->evaluateSpaceChargeEffects();
+
+  m_relFieldChange = fieldChange.first;
+  m_maxFieldChange = fieldChange.second;
+
+  return actualDt;
+}
+
+template <typename I, typename C, typename R, typename F>
+Real
+ItoKMCBackgroundEvaluator<I, C, R, F>::computeDt()
+{
+  CH_TIME("ItoKMCBackgroundEvaluator::computeDt");
+  if (this->m_verbosity > 5) {
+    pout() << "ItoKMCBackgroundEvaluator::computeDt" << endl;
+  }
+
+  Real newDt = 0.0;
+
+  const bool noElectronsPresent = false;
+
+  if ((m_maxFieldChange > m_exitCrit) && (m_exitCrit > 0.0)) {
+    newDt = 0.0;
+
+    pout() << "ItoKMCBackgroundEvaluator -- abort because field changed by more than specified threshold" << endl;
+  }
+  else if (noElectronsPresent) { // Abort if we're out of electrons.
+    newDt = 0.0;
+
+    pout() << "ItoKMCBackgroundEvaluator -- abort because no electrons are present" << endl;
+  }
+  else {
+    newDt = ItoKMCGodunovStepper<I, C, R, F>::computeDt();
+  }
+
+  return newDt;
+}
+
+template <typename I, typename C, typename R, typename F>
 void
 ItoKMCBackgroundEvaluator<I, C, R, F>::printStepReport() noexcept
 {
@@ -82,15 +133,10 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::printStepReport() noexcept
     pout() << "ItoKMCBackgroundEvaluator::printStepReport" << endl;
   }
 
-  const Real k = this->evaluateSpaceChargeEffects();
-
   ItoKMCGodunovStepper<I, C, R, F>::printStepReport();
   const std::string whitespace = "                                   ";
-  pout() << whitespace + "Delta E     = " << 100.0 * k << " (%)" << endl;
-
-  if (k > m_exitCrit) {
-    MayDay::Abort("ItoKMCBackgroundEvaluator -- abort because field changed by more than specified threshold");
-  }
+  pout() << whitespace + "Delta E(max) = " << 100.0 * m_maxFieldChange << " (%)" << endl;
+  pout() << whitespace + "Delta E(rel) = " << 100.0 * m_relFieldChange << " (%)" << endl;
 }
 
 template <typename I, typename C, typename R, typename F>
@@ -136,7 +182,7 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::computeBackgroundField() noexcept
 }
 
 template <typename I, typename C, typename R, typename F>
-Real
+std::pair<Real, Real>
 ItoKMCBackgroundEvaluator<I, C, R, F>::evaluateSpaceChargeEffects() noexcept
 {
   CH_TIME("ItoKMCBackgroundEvaluator::evaluateSpaceChargeEffects");
@@ -172,7 +218,16 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::evaluateSpaceChargeEffects() noexcept
   //
   // PS: I'm doing this with a direct loop because DataOps::getMaxMin will do ALL cells, including ones that are
   //     covered by a finer level. But we only want to evaluate the valid region.
-  Real maxChange = 0.0;
+  Real relChange = -1.0;
+  Real maxChange = -1.0;
+
+  Real maxSpaceChargeField = 0.0;
+  Real minSpaceChargeField = 0.0;
+  Real maxBackgroundField  = 0.0;
+  Real minBackgroundField  = 0.0;
+
+  DataOps::getMaxMin(maxSpaceChargeField, minSpaceChargeField, poissonNorm, 0);
+  DataOps::getMaxMin(maxBackgroundField, minBackgroundField, laplaceNorm, 0);
 
   for (int lvl = 0; lvl <= (this->m_amr)->getFinestLevel(); lvl++) {
     const DisjointBoxLayout& dbl   = (this->m_amr)->getGrids(this->m_fluidRealm)[lvl];
@@ -193,13 +248,13 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::evaluateSpaceChargeEffects() noexcept
 
       auto regularKernel = [&](const IntVect& iv) -> void {
         if (validCells(iv) && ebisbox.isRegular(iv)) {
-          maxChange = std::max(maxChange, std::abs(dataReg(iv, 0)));
+          relChange = std::max(relChange, std::abs(dataReg(iv, 0)));
         }
       };
 
       auto irregularKernel = [&](const VolIndex& vof) -> void {
         if (validCells(vof.gridIndex()) && ebisbox.isIrregular(vof.gridIndex())) {
-          maxChange = std::max(maxChange, std::abs(data(vof, 0)));
+          relChange = std::max(relChange, std::abs(data(vof, 0)));
         }
       };
 
@@ -210,7 +265,10 @@ ItoKMCBackgroundEvaluator<I, C, R, F>::evaluateSpaceChargeEffects() noexcept
     }
   }
 
-  return ParallelOps::max(maxChange);
+  relChange = ParallelOps::max(relChange);
+  maxChange = maxSpaceChargeField / maxBackgroundField - 1.0;
+
+  return std::make_pair(relChange, maxChange);
 }
 
 #include <CD_NamespaceFooter.H>

--- a/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run.inputs
+++ b/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run.inputs
@@ -1,7 +1,7 @@
 # ====================================================================================================
 # Voltage curve
 # ====================================================================================================
-StreamerIntegralCriterion.potential = 3666.67 # [script-altered]
+StreamerIntegralCriterion.potential = 13666.67 # [script-altered]
 StreamerIntegralCriterion.basename  = pout
 
 # ====================================================================================================
@@ -13,10 +13,10 @@ ItoKMCBackgroundEvaluator.exit_crit = 0.05   ## percentage per cell change in fi
 # AmrMesh class options
 # ====================================================================================================
 AmrMesh.lo_corner        = -6E-2 0  -6E-2    ## Low corner of problem domain
-AmrMesh.hi_corner        =  6E-2 45E-3  6E-2 ## High corner of problem domain
+AmrMesh.hi_corner        =  6E-2 6E-2  6E-2 ## High corner of problem domain
 AmrMesh.verbosity        = -1                ## Controls verbosity. 
-AmrMesh.coarsest_domain  = 128 48 128        ## Number of cells on coarsest domain
-AmrMesh.max_amr_depth    = 4                 ## Maximum amr depth
+AmrMesh.coarsest_domain  = 64 32 64        ## Number of cells on coarsest domain
+AmrMesh.max_amr_depth    = 4                ## Maximum amr depth
 AmrMesh.max_sim_depth    = -1                ## Maximum simulation depth
 AmrMesh.fill_ratio       = 1.0               ## Fill ratio for grid generation
 AmrMesh.buffer_size      = 2                 ## Number of cells between grid levels
@@ -50,7 +50,7 @@ Driver.checkpoint_interval             = 1000             ## Checkpoint interval
 Driver.regrid_interval                 = 5                ## Regrid interval
 Driver.write_regrid_files              = false            ## Write regrid files or not.
 Driver.write_restart_files             = false            ## Write restart files or not
-Driver.initial_regrids                 = 8                ## Number of initial regrids
+Driver.initial_regrids                 = 5                ## Number of initial regrids
 Driver.do_init_load_balance            = false            ## If true, load balance the first step in a fresh simulation.
 Driver.start_time                      = 0                ## Start time (fresh simulations only)
 Driver.stop_time                       = 1.0              ## Stop time
@@ -107,12 +107,12 @@ CdrCTU.gmg_smoother         = red_black               ## Relaxation type. 'jacob
 # ====================================================================================================
 FieldSolverMultigrid.verbosity         = -1                # Class verbosity
 FieldSolverMultigrid.jump_bc           = natural           # Jump BC type ('natural' or 'saturation_charge')
-FieldSolverMultigrid.bc.x.lo           = dirichlet 0.0     # Bc type (see docs)
-FieldSolverMultigrid.bc.x.hi           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.x.lo           = neumann 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.x.hi           = neumann 0.0     # Bc type (see docs)
 FieldSolverMultigrid.bc.y.lo           = dirichlet 0.0     # Bc type (see docs)
-FieldSolverMultigrid.bc.y.hi           = neumann   0.0     # Bc type (see docs)
-FieldSolverMultigrid.bc.z.lo           = dirichlet 0.0     # Bc type (see docs)
-FieldSolverMultigrid.bc.z.hi           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.y.hi           = dirichlet 1.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.z.lo           = neumann 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.z.hi           = neumann 0.0     # Bc type (see docs)
 FieldSolverMultigrid.plt_vars          = phi rho E         # Plot variables: 'phi', 'rho', 'E', 'res', 'perm', 'sigma', 'Esol'
 FieldSolverMultigrid.use_regrid_slopes = true              # Use slopes when regridding or not
 FieldSolverMultigrid.kappa_source      = true              # Volume weighted space charge density or not (depends on algorithm)
@@ -127,14 +127,14 @@ FieldSolverMultigrid.gmg_min_iter      = 5                 # Minimum number of i
 FieldSolverMultigrid.gmg_max_iter      = 32                # Maximum number of iterations
 FieldSolverMultigrid.gmg_exit_tol      = 1.E-10            # Residue tolerance
 FieldSolverMultigrid.gmg_exit_hang     = 0.2               # Solver hang
-FieldSolverMultigrid.gmg_min_cells     = 16                # Bottom drop
+FieldSolverMultigrid.gmg_min_cells     = 4                # Bottom drop
 FieldSolverMultigrid.gmg_drop_order    = 0                 # Drop stencil order to 1 if domain is coarser than this.
 FieldSolverMultigrid.gmg_bc_order      = 2                 # Boundary condition order for multigrid
-FieldSolverMultigrid.gmg_bc_weight     = 2                 # Boundary condition weights (for least squares)
+FieldSolverMultigrid.gmg_bc_weight     = 1                 # Boundary condition weights (for least squares)
 FieldSolverMultigrid.gmg_jump_order    = 2                 # Boundary condition order for jump conditions
-FieldSolverMultigrid.gmg_jump_weight   = 2                 # Boundary condition weight for jump conditions (for least squares)
+FieldSolverMultigrid.gmg_jump_weight   = 1                 # Boundary condition weight for jump conditions (for least squares)
 FieldSolverMultigrid.gmg_reduce_order  = false             # If true, always use order=1 EB stencils in coarsened cells
-FieldSolverMultigrid.gmg_bottom_solver = bicgstab          # Bottom solver type. 'simple', 'bicgstab', or 'gmres'
+FieldSolverMultigrid.gmg_bottom_solver = simple 64         # Bottom solver type. 'simple', 'bicgstab', or 'gmres'
 FieldSolverMultigrid.gmg_cycle         = vcycle            # Cycle type. Only 'vcycle' supported for now. 
 FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'jacobi', 'multi_color', or 'red_black'
 

--- a/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run.inputs
+++ b/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run.inputs
@@ -1,0 +1,364 @@
+# ====================================================================================================
+# Voltage curve
+# ====================================================================================================
+StreamerIntegralCriterion.potential = 3666.67 # [script-altered]
+StreamerIntegralCriterion.basename  = pout
+
+# ====================================================================================================
+# ItoKMCBackgroundEvaluator class options
+# ====================================================================================================
+ItoKMCBackgroundEvaluator.exit_crit = 0.05   ## percentage per cell change in field due to space charge before stopping simulation
+
+# ====================================================================================================
+# AmrMesh class options
+# ====================================================================================================
+AmrMesh.lo_corner        = -6E-2 0  -6E-2    ## Low corner of problem domain
+AmrMesh.hi_corner        =  6E-2 45E-3  6E-2 ## High corner of problem domain
+AmrMesh.verbosity        = -1                ## Controls verbosity. 
+AmrMesh.coarsest_domain  = 128 48 128        ## Number of cells on coarsest domain
+AmrMesh.max_amr_depth    = 4                 ## Maximum amr depth
+AmrMesh.max_sim_depth    = -1                ## Maximum simulation depth
+AmrMesh.fill_ratio       = 1.0               ## Fill ratio for grid generation
+AmrMesh.buffer_size      = 2                 ## Number of cells between grid levels
+AmrMesh.grid_algorithm   = tiled             ## Berger-Rigoustous 'br' or 'tiled' for the tiled algorithm
+AmrMesh.box_sorting      = morton            ## 'none', 'shuffle', 'morton'
+AmrMesh.blocking_factor  = 16                ## Blocking factor. 
+AmrMesh.max_box_size     = 16                ## Maximum allowed box size
+AmrMesh.max_ebis_box     = 16                ## Maximum allowed box size for EBIS generation. 
+AmrMesh.ref_rat          = 2 2 2 2 2 2       ## Refinement ratios (mixed ratios are allowed). 
+AmrMesh.num_ghost        = 2                 ## Number of ghost cells. 
+AmrMesh.lsf_ghost        = 2                 ## Number of ghost cells when writing level-set to grid
+AmrMesh.eb_ghost         = 2                 ## Set number of of ghost cells for EB stuff
+AmrMesh.mg_interp_order  = 2                 ## Multigrid interpolation order
+AmrMesh.mg_interp_radius = 2                 ## Multigrid interpolation radius
+AmrMesh.mg_interp_weight = 2                 ## Multigrid interpolation weight (for least squares)
+AmrMesh.centroid_interp  = minmod	     ## Centroid interp stencils. linear, lsq, minmod, etc
+AmrMesh.eb_interp        = minmod            ## EB interp stencils. linear, taylor, minmod, etc
+AmrMesh.redist_radius    = 1                 ## Redistribution radius for hyperbolic conservation laws
+
+
+# ====================================================================================================
+# Driver class options
+# ====================================================================================================
+Driver.verbosity                       = 2                ## Engine verbosity
+Driver.geometry_generation             = chombo-discharge ## Grid generation method, 'chombo-discharge' or 'chombo'
+Driver.geometry_scan_level             = 0                ## Geometry scan level for chombo-discharge geometry generator
+Driver.ebis_memory_load_balance        = false            ## If using Chombo geo-gen, use memory as loads for EBIS generation  
+Driver.output_dt                       = -1.0             ## Output interval (values <= 0 enforces step-based output)
+Driver.plot_interval                   = 10               ## Plot interval
+Driver.checkpoint_interval             = 1000             ## Checkpoint interval
+Driver.regrid_interval                 = 5                ## Regrid interval
+Driver.write_regrid_files              = false            ## Write regrid files or not.
+Driver.write_restart_files             = false            ## Write restart files or not
+Driver.initial_regrids                 = 8                ## Number of initial regrids
+Driver.do_init_load_balance            = false            ## If true, load balance the first step in a fresh simulation.
+Driver.start_time                      = 0                ## Start time (fresh simulations only)
+Driver.stop_time                       = 1.0              ## Stop time
+Driver.max_steps                       = 1000             ## Maximum number of steps
+Driver.geometry_only                   = false            ## Special option that ONLY plots the geometry
+Driver.write_memory                    = false            ## Write MPI memory report
+Driver.write_loads                     = false            ## Write (accumulated) computational loads
+Driver.output_directory                = ./               ## Output directory
+Driver.output_names                    = simulation       ## Simulation output names
+Driver.max_plot_depth                  = -1               ## Restrict maximum plot depth (-1 => finest simulation level)
+Driver.max_chk_depth                   = -1               ## Restrict chechkpoint depth (-1 => finest simulation level)	
+Driver.num_plot_ghost                  = 1                ## Number of ghost cells to include in plots
+Driver.plt_vars                        = levelset         ## 'tags', 'mpi_rank', 'levelset', 'loads'
+Driver.restart                         = 0                ## Restart step (less or equal to 0 implies fresh simulation)
+Driver.allow_coarsening                = true             ## Allows removal of grid levels according to CellTagger
+Driver.grow_geo_tags                   = 2                ## How much to grow tags when using geometry-based refinement. 
+Driver.refine_angles                   = 45.              ## Refine cells if angle between elements exceed this value.
+Driver.refine_electrodes               = 0                ## Refine electrode surfaces. -1 => equal to refine_geometry
+Driver.refine_dielectrics              = 0                ## Refine dielectric surfaces. -1 => equal to refine_geometry
+
+
+# ====================================================================================================
+# CdrCTU solver settings. 
+# ====================================================================================================
+CdrCTU.bc.x.lo              = wall                    ## 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.x.hi              = wall                    ## 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.y.lo              = wall                    ## 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.y.hi              = wall                    ## 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.z.lo              = wall                    ## 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.bc.z.hi              = wall                    ## 'data', 'function', 'wall', 'outflow', or 'solver'
+CdrCTU.slope_limiter        = minmod                  ## Slope limiter. 'none', 'minmod', 'mc', or 'superbee'
+CdrCTU.use_ctu              = true                    ## If true, use CTU. Otherwise it's DTU.
+CdrCTU.plt_vars             = phi vel src dco ebflux  ## Plot variables. Options are 'phi', 'vel', 'dco', 'src'
+CdrCTU.plot_mode            = density                 ## Plot densities 'density' or particle numbers ('numbers')
+CdrCTU.blend_conservation   = true                    ## Turn on/off blending with nonconservative divergenceo
+CdrCTU.which_redistribution = volume                  ## Redistribution type. 'volume', 'mass', or 'none' (turned off)
+CdrCTU.use_regrid_slopes    = true                    ## Turn on/off slopes when regridding
+CdrCTU.gmg_verbosity        = -1                      ## GMG verbosity
+CdrCTU.gmg_pre_smooth       = 12                      ## Number of relaxations in GMG downsweep
+CdrCTU.gmg_post_smooth      = 12                      ## Number of relaxations in upsweep
+CdrCTU.gmg_bott_smooth      = 12                      ## NUmber of relaxations before dropping to bottom solver
+CdrCTU.gmg_min_iter         = 5                       ## Minimum number of iterations
+CdrCTU.gmg_max_iter         = 32                      ## Maximum number of iterations
+CdrCTU.gmg_exit_tol         = 1.E-10                  ## Residue tolerance
+CdrCTU.gmg_exit_hang        = 0.2                     ## Solver hang
+CdrCTU.gmg_min_cells        = 16                      ## Bottom drop
+CdrCTU.gmg_bottom_solver    = bicgstab                ## Bottom solver type. Valid options are 'simple' and 'bicgstab'
+CdrCTU.gmg_cycle            = vcycle                  ## Cycle type. Only 'vcycle' supported for now
+CdrCTU.gmg_smoother         = red_black               ## Relaxation type. 'jacobi', 'multi_color', or 'red_black'
+
+
+# ====================================================================================================
+# FieldSolverMultigrid class options
+# ====================================================================================================
+FieldSolverMultigrid.verbosity         = -1                # Class verbosity
+FieldSolverMultigrid.jump_bc           = natural           # Jump BC type ('natural' or 'saturation_charge')
+FieldSolverMultigrid.bc.x.lo           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.x.hi           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.y.lo           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.y.hi           = neumann   0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.z.lo           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.bc.z.hi           = dirichlet 0.0     # Bc type (see docs)
+FieldSolverMultigrid.plt_vars          = phi rho E         # Plot variables: 'phi', 'rho', 'E', 'res', 'perm', 'sigma', 'Esol'
+FieldSolverMultigrid.use_regrid_slopes = true              # Use slopes when regridding or not
+FieldSolverMultigrid.kappa_source      = true              # Volume weighted space charge density or not (depends on algorithm)
+FieldSolverMultigrid.filter_rho        = 0                 # Number of filterings of space charge before Poisson solve
+FieldSolverMultigrid.filter_potential  = 0                 # Number of filterings of potential after Poisson solve
+
+FieldSolverMultigrid.gmg_verbosity     = -1                # GMG verbosity
+FieldSolverMultigrid.gmg_pre_smooth    = 16                # Number of relaxations in downsweep
+FieldSolverMultigrid.gmg_post_smooth   = 16                # Number of relaxations in upsweep
+FieldSolverMultigrid.gmg_bott_smooth   = 16                # Number of at bottom level (before dropping to bottom solver)
+FieldSolverMultigrid.gmg_min_iter      = 5                 # Minimum number of iterations
+FieldSolverMultigrid.gmg_max_iter      = 32                # Maximum number of iterations
+FieldSolverMultigrid.gmg_exit_tol      = 1.E-10            # Residue tolerance
+FieldSolverMultigrid.gmg_exit_hang     = 0.2               # Solver hang
+FieldSolverMultigrid.gmg_min_cells     = 16                # Bottom drop
+FieldSolverMultigrid.gmg_drop_order    = 0                 # Drop stencil order to 1 if domain is coarser than this.
+FieldSolverMultigrid.gmg_bc_order      = 2                 # Boundary condition order for multigrid
+FieldSolverMultigrid.gmg_bc_weight     = 2                 # Boundary condition weights (for least squares)
+FieldSolverMultigrid.gmg_jump_order    = 2                 # Boundary condition order for jump conditions
+FieldSolverMultigrid.gmg_jump_weight   = 2                 # Boundary condition weight for jump conditions (for least squares)
+FieldSolverMultigrid.gmg_reduce_order  = false             # If true, always use order=1 EB stencils in coarsened cells
+FieldSolverMultigrid.gmg_bottom_solver = bicgstab          # Bottom solver type. 'simple', 'bicgstab', or 'gmres'
+FieldSolverMultigrid.gmg_cycle         = vcycle            # Cycle type. Only 'vcycle' supported for now. 
+FieldSolverMultigrid.gmg_smoother      = red_black         # Relaxation type. 'jacobi', 'multi_color', or 'red_black'
+
+
+# ====================================================================================================
+# ItoSolver class options
+# ====================================================================================================
+ItoSolver.verbosity           = -1               ## Class verbosity
+ItoSolver.merge_algorithm     = reinitialize_bvh ## Particle merging algorithm. Either 'reinitialize' or 'equal_weight_kd'
+ItoSolver.plt_vars            = phi vel dco      ## 'phi', 'vel', 'dco', 'part', 'eb_part', 'dom_part', 'src_part', 'energy_density', 'energy'
+ItoSolver.intersection_alg    = bisection        ## Intersection algorithm for EB-particle intersections.
+ItoSolver.bisect_step         = 1.E-4            ## Bisection step length for intersection tests
+ItoSolver.normal_max          = 5.0              ## Maximum value (absolute) that can be drawn from the exponential distribution.
+ItoSolver.redistribute        = false            ## Turn on/off redistribution. 
+ItoSolver.blend_conservation  = false            ## Turn on/off blending with nonconservative divergenceo
+ItoSolver.checkpointing       = particles        ## 'particles' or 'numbers'
+ItoSolver.ppc_restart         = 32               ## Maximum number of computational particles to generate for restarts.
+ItoSolver.irr_ngp_deposition  = true             ## Force irregular deposition in cut cells or not
+ItoSolver.irr_ngp_interp      = true             ## Force irregular interpolation in cut cells or not
+ItoSolver.mobility_interp     = direct           ## How to interpolate mobility, 'direct' or 'velocity', i.e. either mu_p = mu(X_p) or mu_p = (mu*E)(X_p)/E(X_p)
+ItoSolver.plot_deposition     = cic              ## Cloud-in-cell for plotting particles.
+ItoSolver.deposition          = cic              ## Deposition type. 
+ItoSolver.deposition_cf       = halo             ## Coarse-fine deposition. interp, halo, or halo_ngp
+
+
+# ====================================================================================================
+# SurfaceODESolver solver settings. 
+# ====================================================================================================
+SurfaceODESolver.verbosity = -1                # Chattiness
+SurfaceODESolver.regrid    = conservative      # Regrid method. 'conservative' or 'arithmetic'
+SurfaceODESolver.plt_vars  = phi               # Plot variables. Valid arguments are 'phi' and 'rhs'
+
+
+# ====================================================================================================
+# McPhoto class options
+# ====================================================================================================
+McPhoto.verbosity            = -1            ## Solver verbosity
+McPhoto.instantaneous        = true          ## Instantaneous transport or not
+McPhoto.max_photons_per_cell = 32            ## Maximum no. generated in a cell (<= 0 yields physical photons)
+McPhoto.num_sampling_packets = 1             ## Number of sub-sampling packets for max_photons_per_cell. Only for instantaneous=true
+McPhoto.blend_conservation   = false         ## Switch for blending with the nonconservative divergence
+McPhoto.transparent_eb       = false         ## Turn on/off transparent boundaries. Only for instantaneous=true
+McPhoto.plt_vars             = phi src phot  ## Available are 'phi' and 'src', 'phot', 'eb_phot', 'dom_phot', 'bulk_phot', 'src_phot'
+McPhoto.intersection_alg     = bisection     ## EB intersection algorithm. Supported are: 'raycast' 'bisection'
+McPhoto.bisect_step          = 1.E-4         ## Bisection step length for intersection tests
+McPhoto.bc_x_low             = outflow       ## Boundary condition. 'outflow', 'symmetry', or 'wall'
+McPhoto.bc_x_high            = outflow       ## Boundary condition
+McPhoto.bc_y_low             = outflow       ## Boundary condition
+McPhoto.bc_y_high            = outflow       ## Boundary condition
+McPhoto.bc_z_low             = outflow       ## Boundary condition
+McPhoto.bc_z_high            = outflow       ## Boundary condition
+McPhoto.photon_generation    = deterministic ## Volumetric source term. 'deterministic' or 'stochastic'
+McPhoto.source_type          = number        ## 'number'      -> Source term contains the number of photons produced
+                                             ## 'volume'      -> Source terms contains the number of photons produced per unit volume
+                                             ## 'volume_rate' -> Source terms contains the volumetric rate
+                                             ## 'rate'        -> Source terms contains the rate
+McPhoto.deposition           = cic           ## 'ngp'  -> nearest grid point, 'cic' -> cloud-in-cell
+McPhoto.deposition_cf        = halo          ## Coarse-fine deposition. Must be 'interp' or 'halo'
+
+
+# ====================================================================================================
+# Rod geometry
+# ====================================================================================================
+Rod.radius = 0.001       # [script-altered] Rod radius
+Rod.point2 = 0.0 20E-3 0.0	# One endpoint
+Rod.point1 = 0.0 99 0.0  	# Other endpoint
+Rod.live   = true        	# Live or not
+
+# ====================================================================================================
+# ItoKMCGodunovStepper class options
+# ====================================================================================================
+ItoKMCGodunovStepper.checkpoint_particles                  = true                 ## If true, regrid on restart is supported (otherwise it's not)
+ItoKMCGodunovStepper.verbosity                             = -1                   ## Verbosity
+ItoKMCGodunovStepper.secondary_emission                    = after_reactions      ## When to emit secondary particles. Either 'before_reactions' or 'after_reactions'
+ItoKMCGodunovStepper.abort_on_failure                      = true                 ## Abort on Poisson solver failure or not
+ItoKMCGodunovStepper.redistribute_cdr                      = true                 ## Turn on/off reactive redistribution
+ItoKMCGodunovStepper.limit_parallel_diffusion              = false                ## If true, particles do not diffuse against their drift direction
+ItoKMCGodunovStepper.profile                               = false                ## Turn on/off run-time profiling
+ItoKMCGodunovStepper.plt_vars                              = current_density      ## 'conductivity', 'current_density', 'particles_per_patch'
+ItoKMCGodunovStepper.dual_grid                             = false                ## Turn on/off dual-grid functionality
+ItoKMCGodunovStepper.load_balance_fluid                    = false                ## Turn on/off fluid realm load balancing.
+ItoKMCGodunovStepper.load_balance_particles                = false                ## Turn on/off particle load balancing
+ItoKMCGodunovStepper.load_indices                          = -1                   ## Which particle containers to use for load balancing (-1 => all)
+ItoKMCGodunovStepper.load_per_cell                         = 1.0                  ## Default load per grid cell.
+ItoKMCGodunovStepper.box_sorting                           = morton               ## Box sorting when load balancing
+ItoKMCGodunovStepper.particles_per_cell                    = 64                   ## Max computational particles per cell
+ItoKMCGodunovStepper.merge_interval                        = 1                    ## Time steps between superparticle merging
+ItoKMCGodunovStepper.regrid_superparticles                 = false                ## Make superparticles during regrids
+ItoKMCGodunovStepper.physics_dt_factor                     = 1.0                  ## Physics-based time step factor
+ItoKMCGodunovStepper.min_particle_advection_cfl            = 0.1                  ## Advective time step CFL restriction
+ItoKMCGodunovStepper.max_particle_advection_cfl            = 5.0                  ## Advective time step CFL restriction
+ItoKMCGodunovStepper.min_particle_diffusion_cfl            = 0.0                  ## Diffusive time step CFL restriction
+ItoKMCGodunovStepper.max_particle_diffusion_cfl            = 1.E99                ## Diffusive time step CFL restriction
+ItoKMCGodunovStepper.min_particle_advection_diffusion_cfl  = 0.0                  ## Advection-diffusion time step CFL restriction
+ItoKMCGodunovStepper.max_particle_advection_diffusion_cfl  = 1.E99                ## Advection-diffusion time step CFL restriction
+ItoKMCGodunovStepper.fluid_advection_diffusion_cfl         = 0.5                  ## Advection-diffusion time step CFL restriction
+ItoKMCGodunovStepper.relax_dt_factor                       = 100.0                ## Relaxation time step restriction.
+ItoKMCGodunovStepper.min_dt                                = 0.0                  ## Minimum permitted time step
+ItoKMCGodunovStepper.max_dt                                = 1.E99                ## Maximum permitted time step
+ItoKMCGodunovStepper.max_growth_dt                         = 1.E99                ## Maximum permitted time step increase (dt * factor)
+ItoKMCGodunovStepper.max_shrink_dt                         = 1.E99                ## Maximum permissible time step reduction (dt/factor)
+ItoKMCGodunovStepper.extend_conductivity                   = true                 ## Permit particles to live outside the EB to avoid bad gradients near EB
+ItoKMCGodunovStepper.smooth_conductivity                   = false                ## Use bilinear smoothing on the conductivity.
+ItoKMCGodunovStepper.cond_filter_num                       = 0                    ## Number of filterings for conductivity
+ItoKMCGodunovStepper.cond_filter_max_stride                = 1                    ## Maximum stride for filter
+ItoKMCGodunovStepper.cond_filter_alpha                     = 0.5                  ## Filtering factor (0.5 is a bilinear filter)
+ItoKMCGodunovStepper.filter_num                            = 0                    ## Number of filterings for the space-density
+ItoKMCGodunovStepper.filter_max_stride                     = 1                    ## Maximum stride for filter
+ItoKMCGodunovStepper.filter_alpha                          = 0.5                  ## Filtering factor (0.5 is a bilinear filter)
+ItoKMCGodunovStepper.rho_filter_num                        = 0                    ## Number of filterings for the space-density
+ItoKMCGodunovStepper.rho_filter_max_stride                 = 1                    ## Maximum stride for filter
+ItoKMCGodunovStepper.rho_filter_alpha                      = 0.5                  ## Filtering factor (0.5 is a bilinear filter)
+ItoKMCGodunovStepper.eb_tolerance                          = 0.0                  ## EB intersection test tolerance
+ItoKMCGodunovStepper.algorithm                             = euler_maruyama       ## Integration algorithm. 'euler_maruyama' or 'trapezoidal'
+
+
+# ====================================================================================================
+# ItoKMCJSON class options
+# ====================================================================================================
+ItoKMCJSON.verbose            = false           ## Turn on/off verbosity
+ItoKMCJSON.debug              = false           ## Turn on/off debugging
+ItoKMCJSON.chemistry_file     = failed_run_chemistry.json  ## Chemistry file. Must be supplied by the user. 
+
+# Kinetic Monte Carlo solver settings. 
+ItoKMCJSON.max_new_particles  = 32              ## Maximum number of computational particles to produce in reaction step
+ItoKMCJSON.max_new_photons    = 32              ## Maximum number of computational photons to produce in reaction step	
+ItoKMCJSON.increment_weights  = false           ## If true, increment existing particle weights rather than creating new ones
+ItoKMCJSON.crit_num           = 5               ## How many firings away from a Negative particle number?
+ItoKMCJSON.prop_eps           = 5.0             ## Maximum relative change in propensity function
+ItoKMCJSON.SSA_num            = 5               ## How many SSA steps to run when tau-leaping is inefficient
+ItoKMCJSON.SSA_lim            = 5.0             ## When to enter SSA instead of tau-leaping
+ItoKMCJSON.max_iter           = 50              ## Maximum number of iterations for implicit algorithms
+ItoKMCJSON.exit_tolerance     = 1.E-6           ## Exit tolerance for implicit algorithms
+ItoKMCJSON.algorithm          = hybrid_midpoint ## 'ssa', 'tau_plain', 'tau_midpoint', 'hybrid_plain', or 'hybrid_midpoint'
+
+
+# ====================================================================================================
+# ITO_PLASMA_STREAMER_TAGGER CLASS OPTIONS
+# ====================================================================================================
+ItoKMCStreamerTagger.verbosity         = -1           # Verbosity
+ItoKMCStreamerTagger.plot              = false        # Turn on/off plotting of input fields.
+ItoKMCStreamerTagger.num_tag_boxes     = 0            # Number of allowed tag boxes (0 = tags allowe everywhere)
+ItoKMCStreamerTagger.tag_box1_lo       = 0.0 0.0 0.0  # Only allow tags that fall between
+ItoKMCStreamerTagger.tag_box1_hi       = 0.0 0.0 0.0  # these two corners
+ItoKMCStreamerTagger.buffer            = 8            # Grow tagged cells
+
+ItoKMCStreamerTagger.refine_curvature  = 1.0e99       # Curvature refinement
+ItoKMCStreamerTagger.coarsen_curvature = 1.0e99       # Curvature coarsening	
+ItoKMCStreamerTagger.refine_alpha      = 1.0          # Set alpha refinement. Lower  => More mesh
+ItoKMCStreamerTagger.coarsen_alpha     = 0.1          # Set alpha coarsening. Higher => Less mesh
+ItoKMCStreamerTagger.max_coarsen_lvl   = 0            # Set max coarsening depth
+
+
+# ====================================================================================================
+# !! BELOW THIS POINT !!
+# Inception Stepper specific options
+# ====================================================================================================
+
+# ====================================================================================================
+# TracerParticleSolver class options
+# ====================================================================================================
+TracerParticleSolver.verbosity     = -1     # Solver verbosity level. 
+TracerParticleSolver.deposition    = ngp    # Deposition method. Must be 'ngp' or 'cic'
+TracerParticleSolver.interpolation = cic    # Interpolation method. Must be 'ngp' or 'cic'
+TracerParticleSolver.deposition_cf = halo   # Coarse-fine deposition. Must be interp or halo
+TracerParticleSolver.plot_weight   = true   # Turn on/off plotting of the particle weight.
+TracerParticleSolver.plot_velocity = true   # Turn on/off plotting of the particle velocities.
+TracerParticleSolver.volume_scale  = false  # If true, depositions yield density * volume instead of just volume
+
+# ====================================================================================================
+# DischargeInceptionStepper class options
+# ====================================================================================================
+DischargeInceptionStepper.verbosity     = -1                    # Chattiness.
+DischargeInceptionStepper.profile       = false
+DischargeInceptionStepper.full_integration          = true
+DischargeInceptionStepper.mode          = stationary            # Mode (stationary or transient)
+DischargeInceptionStepper.eval_townsend    = true               ## Evaluate Townsend criterion or not (only for stationary)
+DischargeInceptionStepper.inception_alg    = trapz              ## Integration algorithm. Either euler or trapz
+DischargeInceptionStepper.output_file   = report.txt            # Output file
+DischargeInceptionStepper.K_inception   = 10                    # User-specified inception value
+DischargeInceptionStepper.plt_vars      = K inc alpha eta field poisson ## Plot variables
+
+# Particle integration controls
+DischargeInceptionStepper.min_phys_dx      = 1.E-10		## Minimum permitted physical step size
+DischargeInceptionStepper.max_phys_dx      = 1.E99		## Maximum permitted physical step size
+DischargeInceptionStepper.min_grid_dx      = 0.5		## Minimum permitted grid step size
+DischargeInceptionStepper.max_grid_dx      = 5.0		## Maximum permitted grid step size
+DischargeInceptionStepper.alpha_dx         = 5.0		## Step size relative to avalanche length
+DischargeInceptionStepper.grad_alpha_dx    = 0.1		## Maximum step size relative to alpha/grad(alpha)
+DischargeInceptionStepper.townsend_grid_dx = 2.0		## Space step to use for Townsend tracking
+
+# Static mode
+DischargeInceptionStepper.voltage_lo    = 2E3                   # Low voltage multiplier
+DischargeInceptionStepper.voltage_hi    = 12E3                  # Highest voltage multiplier
+DischargeInceptionStepper.voltage_steps = 5                     # Number of voltage steps
+
+# Dynamic mode
+DischargeInceptionStepper.ion_transport = true                  # Turn on/off ion transport
+DischargeInceptionStepper.transport_alg = heun                  # Transport algorithm. 'euler', 'heun', or 'imex'
+DischargeInceptionStepper.cfl           = 0.8                   # CFL time step for dynamic mode
+DischargeInceptionStepper.first_dt      = 1.E-9                 # First time step to be used. 
+DischargeInceptionStepper.min_dt        = 1.E-9                 # Minimum permitted time step
+DischargeInceptionStepper.max_dt        = 1.E99                 # Maximum permitted time step
+DischargeInceptionStepper.voltage_eps   = 0.02                  # Permitted relative change in V(t) when computing dt
+DischargeInceptionStepper.max_dt_growth = 0.05                  # Maximum relative change in dt when computing dt
+
+# ====================================================================================================
+# DischargeInceptionTagger class options
+# ====================================================================================================
+DischargeInceptionTagger.verbosity   = -1    # Tagger chattiness. 
+DischargeInceptionTagger.buffer      = 4     # Grown buffer around flagged cells
+DischargeInceptionTagger.max_voltage = 50E3 # Maximum applied voltage 
+DischargeInceptionTagger.ref_alpha   = 1.0   # Refinement curvature criterion. Lower => more mesh
+DischargeInceptionTagger.plot        = false # Plot tagging field or not.
+
+# ====================================================================================================
+# Parameters for lightning impulse (used for dynamic runs)
+# ====================================================================================================
+lightning_impulse.peak       = 50E3
+lightning_impulse.start      = 50E-9
+lightning_impulse.front_time = 1.2E-6
+lightning_impulse.tail_time  = 50E-6
+
+# ====================================================================================================
+# Other physics adjustable physics data
+# ====================================================================================================
+DischargeInception.second_townsend = 1.E-3

--- a/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run_chemistry.json
+++ b/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run_chemistry.json
@@ -1,0 +1,276 @@
+{
+    "gas": {
+        "background species": [
+            {
+                "id": "N2",
+                "molar fraction": {
+                    "type": "constant",
+                    "value": 0.8
+                }
+            },
+            {
+                "id": "O2",
+                "molar fraction": {
+                    "type": "constant",
+                    "value": 0.2
+                }
+            }
+        ],
+        "law": {
+            "id": "ideal_gas",
+            "plot": true,
+            "ideal_gas": {
+                "type": "ideal",
+                "temperature": 300,
+                "pressure": 100000.0
+            },
+            "my_ideal_gas": {
+                "pressure": 100000.0
+            }
+        }
+    },
+    "particle placement": {
+        "method": "downstream",
+        "species": "e"
+    },
+    "alpha": {
+        "type": "auto",
+        "species": "e"
+    },
+    "eta": {
+        "type": "auto",
+        "species": "e"
+    },
+    "plasma species": [
+        {
+            "id": "e",
+            "Z": -1,
+            "solver": "ito",
+            "mobile": true,
+            "diffusive": true,
+            "mobility": {
+                "type": "table vs E/N",
+                "file": "electron_transport_data.dat",
+                "header": "E/N (Td)\tMobility *N (1/m/V/s)",
+                "E/N column": 0,
+                "mu*N column": 1,
+                "min E/N": 1,
+                "max E/N": 2000000.0,
+                "points": 10000,
+                "spacing": "exponential"
+            },
+            "diffusion": {
+                "type": "table vs E/N",
+                "file": "electron_transport_data.dat",
+                "header": "E/N (Td)\tDiffusion coefficient *N (1/m/s)",
+                "E/N column": 0,
+                "D*N column": 1,
+                "min E/N": 10,
+                "max E/N": 2000000.0,
+                "points": 10000,
+                "spacing": "exponential"
+            },
+            "temperature": {
+                "type": "table vs E/N",
+                "file": "electron_transport_data.dat",
+                "header": "E/N (Td)\tMean energy (eV)",
+                "E/N column": 0,
+                "eV column": 1,
+                "min E/N": 10,
+                "max E/N": 2000000.0,
+                "points": 1000,
+                "spacing": "exponential"
+            },
+            "initial particles": [
+                {
+                    "gaussian distribution": {
+                        "center": [
+                            -0.000521,
+                            0.020278,
+                            -0.000462
+                        ],
+                        "radius": 0.002,
+                        "num particles": 100,
+                        "weight": 1
+                    }
+                }
+            ]
+        },
+        {
+            "id": "N2+",
+            "Z": 1,
+            "solver": "ito",
+            "mobile": true,
+            "diffusive": true,
+            "mobility": {
+                "type": "constant",
+                "value": 0.0002
+            },
+            "diffusion": {
+                "type": "constant",
+                "value": 5e-06
+            }
+        },
+        {
+            "id": "O2+",
+            "Z": 1,
+            "solver": "ito",
+            "mobile": true,
+            "diffusive": true,
+            "mobility": {
+                "type": "constant",
+                "value": 0.0002
+            },
+            "diffusion": {
+                "type": "constant",
+                "value": 5e-06
+            }
+        },
+        {
+            "id": "O2-",
+            "Z": -1,
+            "solver": "ito",
+            "mobile": true,
+            "diffusive": true,
+            "mobility": {
+                "type": "constant",
+                "value": 0.0002
+            },
+            "diffusion": {
+                "type": "constant",
+                "value": 5e-06
+            }
+        }
+    ],
+    "photon species": [
+        {
+            "id": "Y",
+            "kappa": {
+                "type": "stochastic B",
+                "chi min": 0.02625,
+                "chi max": 1.5,
+                "neutral": "O2"
+            }
+        }
+    ],
+    "plasma reactions": [
+        {
+            "reaction": "e + N2 -> e + e + N2+",
+            "description": "N2 ionization",
+            "type": "table vs E/N",
+            "file": "electron_transport_data.dat",
+            "header": "C25   N2    Ionization    15.60 eV",
+            "E/N column": 0,
+            "rate/N column": 1,
+            "min E/N": 1.0,
+            "max E/N": 10000.0,
+            "num points": 1000,
+            "spacing": "exponential"
+        },
+        {
+            "reaction": "e + O2 -> e + e + O2+",
+            "description": "O2 ionization",
+            "type": "table vs E/N",
+            "file": "electron_transport_data.dat",
+            "header": "C42   O2    Ionization    12.06 eV",
+            "E/N column": 0,
+            "rate/N column": 1,
+            "min E/N": 1.0,
+            "max E/N": 10000.0,
+            "num points": 1000,
+            "spacing": "exponential"
+        },
+        {
+            "reaction": "e + O2 -> O2-",
+            "description": "Dissociative attachment",
+            "type": "table vs E/N",
+            "file": "electron_transport_data.dat",
+            "header": "C27   O2    Attachment",
+            "E/N column": 0,
+            "rate/N column": 1,
+            "min E/N": 1.0,
+            "max E/N": 10000.0,
+            "num points": 1000,
+            "spacing": "exponential"
+        },
+        {
+            "reaction": "e + O2 + O2 -> O2- + O2",
+            "description": "Three-body attachment",
+            "type": "table vs E/N",
+            "file": "electron_transport_data.dat",
+            "header": "C26   O2    Attachment",
+            "E/N column": 0,
+            "rate/N column": 1,
+            "min E/N": 1.0,
+            "max E/N": 1000.0,
+            "num points": 10000,
+            "spacing": "exponential",
+            "scale rate/N": 1e-06
+        },
+        {
+            "reaction": "O2- + @ -> e + (O2)",
+            "@": [
+                "O2",
+                "N2"
+            ],
+            "description": "Detachment",
+            "type": "table vs E/N",
+            "file": "detachment_rate.dat",
+            "E/N column": 0,
+            "rate/N column": 1,
+            "min E/N": 1.0,
+            "max E/N": 1000.0,
+            "num points": 10000,
+            "spacing": "exponential"
+        },
+        {
+            "reaction": "e + N2 -> e + Y + (N2)",
+            "description": "EUV generation",
+            "type": "table vs E/N",
+            "file": "electron_transport_data.dat",
+            "header": "C25   N2    Ionization    15.60 eV",
+            "E/N column": 0,
+            "rate/N column": 1,
+            "min E/N": 1.0,
+            "max E/N": 10000.0,
+            "num points": 1000,
+            "spacing": "exponential",
+            "efficiency": 0.1,
+            "quenching pressure": 4000.0
+        }
+    ],
+    "photoionization": [
+        {
+            "reaction": "Y + (O2) -> e + O2+",
+            "efficiency": 1.0
+        },
+        {
+            "reaction": "Y + (O2) -> (null)",
+            "efficiency": 0.0
+        }
+    ],
+    "electrode emission": [
+        {
+            "reaction": "N2+ -> @",
+            "@": [
+                "e",
+                "(null)"
+            ],
+            "efficiencies": [
+                0.001,
+                0.999
+            ]
+        },
+        {
+            "reaction": "O2+ -> @",
+            "@": [
+                "e",
+                "(null)"
+            ],
+            "efficiencies": [
+                0.001,
+                0.999
+            ]
+        }
+    ]
+}

--- a/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run_pout.0
+++ b/Exec/Examples/ItoKMC/StreamerIntegralCriterion/failed_run_pout.0
@@ -1,0 +1,722 @@
+Driver::setupAndRun(std::string)
+EBIndexSpace::define - From domain
+  Building finest level...
+Entering EBISLevel::EBISLevel called by EBIndexSpace::buildFirstLevel...
+Exiting EBISLevel::EBISLevel called by EBIndexSpace::buildFirstLevel...
+ebis_after_first_level_bui|Mem Usage: OS=   178.914 (vm=  9098.758) MT_peak=     0.442 MT_current=     0.285  OSPeakRSS=   178.914 (vm=  9098.758) (MB)
+    irreg VoFs    : 60092
+    arcs          : 302304
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 1...
+    irreg VoFs    : 14608
+    arcs          : 73960
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 2...
+    irreg VoFs    : 3864
+    arcs          : 19780
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 3...
+    irreg VoFs    : 1068
+    arcs          : 5572
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 4...
+    irreg VoFs    : 316
+    arcs          : 1696
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 5...
+    irreg VoFs    : 56
+    arcs          : 336
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 6...
+    irreg VoFs    : 28
+    arcs          : 168
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 7...
+    irreg VoFs    : 16
+    arcs          : 96
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 8...
+    irreg VoFs    : 8
+    arcs          : 48
+    multi VoFs    : 0
+    zero VoFs     : 0
+    zero VoFs arcs: 0
+
+  Building level 9...
+    Empty
+
+       ebis_leaving_define|Mem Usage: OS=   179.410 (vm=  9098.758) MT_peak=     0.513 MT_current=     0.292  OSPeakRSS=   179.410 (vm=  9098.758) (MB)
+MemoryReport::getMaxMinMemoryUsage:	 Max peak = 8.23422	 Min peak = 0.426722	 Max unfreed = 3.92554	 Min unfreed = 0.224434
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 22 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 20 (MB)
+	Max peak memory       = 23 (MB)
+=======================================================================
+
+Driver::writePlotFile(string)
+Driver::run(Real, Real, int)
+=================================
+Driver::run -- starting run
+
+=======================================================================
+Driver::Grid report - timestep = 0
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 21 (MB)
+	Max peak memory       = 28 (MB)
+=======================================================================
+
+
+Driver::Time step report -- Time step #1
+                                   Time  = 1.30133e-08
+                                   dt    = 1.30133e-08
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 1.00709e-14 (e)
+                                   Qplus       = 1.60218e-19
+                                   Qminu       = -8.65175e-18
+                                   Qsurf       = 0
+                                   Qtot        = -8.49154e-18
+                                   CFL (Ito)   = 5.05171
+                                   CFL (CDR)   = 7.23887e-317
+                                   dt/dt_relax = 2.9287e-06
+                                   #Particles  = 0 (54)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 17 (on rank = 199)
+                                   #Avg. part. = 0.105469
+                                   #Dev. part. = 1.1183 (1060.31%)
+                                   Delta E     = 3.05455e-05 (%)
+                                --  0.10 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 00s 144ms
+                                -- Last time step        : 000h 00m 00s 144ms
+                                -- Wall time per/1E-06   : 000h 00m 11s 097ms
+                                -- Estimated remaining   : 000h 02m 24s 272ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::Time step report -- Time step #2
+                                   Time  = 2.5866e-08
+                                   dt    = 1.28527e-08
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 6.43429e-15 (e)
+                                   Qplus       = 1.60218e-19
+                                   Qminu       = -7.20979e-18
+                                   Qsurf       = 0
+                                   Qtot        = -7.04958e-18
+                                   CFL (Ito)   = 5.0503
+                                   CFL (CDR)   = 7.14955e-317
+                                   dt/dt_relax = 8.01674e-07
+                                   #Particles  = 0 (46)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 13 (on rank = 224)
+                                   #Avg. part. = 0.0898438
+                                   #Dev. part. = 0.912015 (1015.11%)
+                                   Delta E     = 3.22038e-05 (%)
+                                --  0.20 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 00s 307ms
+                                -- Last time step        : 000h 00m 00s 125ms
+                                -- Wall time per/1E-06   : 000h 00m 09s 798ms
+                                -- Estimated remaining   : 000h 02m 33s 330ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::Time step report -- Time step #3
+                                   Time  = 3.97109e-08
+                                   dt    = 1.38449e-08
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 3.21714e-15 (e)
+                                   Qplus       = 1.60218e-19
+                                   Qminu       = -6.24849e-18
+                                   Qsurf       = 0
+                                   Qtot        = -6.08827e-18
+                                   CFL (Ito)   = 5.04923
+                                   CFL (CDR)   = 7.70148e-317
+                                   dt/dt_relax = 9.70145e-07
+                                   #Particles  = 0 (40)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 11 (on rank = 199)
+                                   #Avg. part. = 0.078125
+                                   #Dev. part. = 0.774187 (990.959%)
+                                   Delta E     = 6.1077e-05 (%)
+                                --  0.30 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 00s 502ms
+                                -- Last time step        : 000h 00m 00s 159ms
+                                -- Wall time per/1E-06   : 000h 00m 11s 491ms
+                                -- Estimated remaining   : 000h 02m 47s 152ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::Time step report -- Time step #4
+                                   Time  = 5.5043e-08
+                                   dt    = 1.53322e-08
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 3.21714e-15 (O2+)
+                                   Qplus       = 1.60218e-19
+                                   Qminu       = -5.76784e-18
+                                   Qsurf       = 0
+                                   Qtot        = -5.60762e-18
+                                   CFL (Ito)   = 5.04575
+                                   CFL (CDR)   = 8.52879e-317
+                                   dt/dt_relax = 1.08852e-06
+                                   #Particles  = 0 (37)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 10 (on rank = 199)
+                                   #Avg. part. = 0.0722656
+                                   #Dev. part. = 0.704791 (975.279%)
+                                   Delta E     = 1.7563e-05 (%)
+                                --  0.40 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 00s 667ms
+                                -- Last time step        : 000h 00m 00s 124ms
+                                -- Wall time per/1E-06   : 000h 00m 08s 114ms
+                                -- Estimated remaining   : 000h 02m 46s 314ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::Time step report -- Time step #5
+                                   Time  = 7.73264e-08
+                                   dt    = 2.22834e-08
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 3.21714e-15 (O2+)
+                                   Qplus       = 1.60218e-19
+                                   Qminu       = -5.60762e-18
+                                   Qsurf       = 0
+                                   Qtot        = -5.4474e-18
+                                   CFL (Ito)   = 5.06333
+                                   CFL (CDR)   = 1.23955e-316
+                                   dt/dt_relax = 1.24874e-06
+                                   #Particles  = 0 (36)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 10 (on rank = 199)
+                                   #Avg. part. = 0.0703125
+                                   #Dev. part. = 0.689583 (980.74%)
+                                   Delta E     = 1.73613e-05 (%)
+                                --  0.50 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 00s 830ms
+                                -- Last time step        : 000h 00m 00s 123ms
+                                -- Wall time per/1E-06   : 000h 00m 05s 559ms
+                                -- Estimated remaining   : 000h 02m 45s 214ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::regrid - Didn't find any new cell tags. Skipping the regrid step
+
+
+=======================================================================
+Driver::Grid report - timestep = 5
+---------------------------------------------------------
+	MPI ranks................ = 512
+	Finest level............. = 2
+	Finest AMR domain........ = 512 x 192 x 512
+	Coarsest AMR domain...... = 128 x 48 x 128
+	Refinement ratios........ = 2 2 
+	Grid sparsity............ = 0.0172526
+	Finest dx................ = 0.000234375
+	Total number boxes....... = 212
+	Number of cells.......... = 868,352
+	Including ghost cells.... = 1,696,000
+	Valid # of cells......... = 858,112
+	Total # of boxes (lvl)... = 192  16  4  
+	Total # of cells (lvl)... = 786,432  65,536  16,384  
+	Valid # of cells (lvl)... = 778,240  63,488  16,384  
+	**************
+	Realm = primal
+	...Proc. # of valid cells... = 0
+	...Including ghost cells.... = 0
+	...Proc. # of boxes......... = 0
+	...Proc. # of boxes (lvl)... = 0  0  0  
+	...Proc. # of cells (lvl)... = 0  0  0  
+	Unfreed memory        = 3 (MB)
+	Peak memory usage     = 6 (MB)
+	Min unfreed memory    = 2 (MB)
+	Min peak memory       = 2 (MB)
+	Max unfreed memory    = 21 (MB)
+	Max peak memory       = 29 (MB)
+=======================================================================
+
+
+Driver::Time step report -- Time step #6
+                                   Time  = 1.15871e-07
+                                   dt    = 3.85449e-08
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 3.21714e-15 (O2+)
+                                   Qplus       = 1.60218e-19
+                                   Qminu       = -5.4474e-18
+                                   Qsurf       = 0
+                                   Qtot        = -5.28718e-18
+                                   CFL (Ito)   = 5.10953
+                                   CFL (CDR)   = 2.14413e-316
+                                   dt/dt_relax = 8.5914e-07
+                                   #Particles  = 0 (35)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 10 (on rank = 199)
+                                   #Avg. part. = 0.0683594
+                                   #Dev. part. = 0.676918 (990.234%)
+                                   Delta E     = 1.56567e-05 (%)
+                                --  0.60 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 01s 014ms
+                                -- Last time step        : 000h 00m 00s 123ms
+                                -- Wall time per/1E-06   : 000h 00m 03s 200ms
+                                -- Estimated remaining   : 000h 02m 48s 055ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::Time step report -- Time step #7
+                                   Time  = 3.00809e-06
+                                   dt    = 2.89222e-06
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 106.62 (Td)
+                                   Max n/N     = 3.21714e-15 (O2+)
+                                   Qplus       = 5.02557e-06
+                                   Qminu       = -5.02557e-06
+                                   Qsurf       = 0
+                                   Qtot        = -3.68459e-18
+                                   CFL (Ito)   = 5.00053
+                                   CFL (CDR)   = 1.60885e-314
+                                   dt/dt_relax = 8.12998e-07
+                                   #Particles  = 0 (538)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 262 (on rank = 222)
+                                   #Avg. part. = 1.05078
+                                   #Dev. part. = 16.3134 (1552.5%)
+                                   Delta E     = 3.41606e-05 (%)
+                                --  0.70 percentage of time steps completed
+                                --  0.00 percentage of simulation time completed
+                                -- Elapsed time          : 000h 00m 01s 172ms
+                                -- Last time step        : 000h 00m 00s 123ms
+                                -- Wall time per/1E-06   : 000h 00m 00s 042ms
+                                -- Estimated remaining   : 000h 02m 46s 382ms
+                                -- Unfreed memory        : 0(MB)
+                                -- Peak memory usage     : 0(MB)
+                                -- Max unfreed memory    : 0(MB)
+                                -- Max peak memory usage : 0(MB)
+
+Driver::Time step report -- Time step #8
+                                   Time  = 3.00835e-06
+                                   dt    = 2.57054e-10
+                                   dt restricted by 'Advection (Ito)'
+                                   Emax        = 173775 (Td)
+                                   Max n/N     = 0.062824 (O2+)
+                                   Qplus       = 0.65051
+                                   Qminu       = -0.0223672
+                                   Qsurf       = 0
+                                   Qtot        = 0.628142
+                                   CFL (Ito)   = 0.101006
+                                   CFL (CDR)   = 1.42991e-318
+                                   dt/dt_relax = 113687
+                                   #Particles  = 0 (3,680)
+                                   #EB part.   = 0 (0)
+                                   #Dom. part. = 0 (0)
+                                   #Src. part. = 0 (0)
+                                   #Min part.  = 0 (on rank = 0)
+                                   #Max part.  = 1356 (on rank = 222)
+                                   #Avg. part. = 7.1875
+                                   #Dev. part. = 93.9829 (1307.59%)
+                                   Delta E     = 407615 (%)
+


### PR DESCRIPTION
Flikket på litt slik at det er maks-felt som evalueres og så blir det exit hvis den endringen blir for stor.

Plot-fil blir skrevet til crash-mappa.

Noen endringer i output-filen; når det kjører så står det slik som vedlagt under. Det beste er nå å bruke pout-filen som trigger på om en simulering avbrøt av "riktig" grunn.

Til slutt så har jeg endret litt på feltbetingelsen, der vi bruker Neumann på veggene og potensial på stanga og øvre vegg. Dette er representativt for "protrusion-plane" geometri. Tidligere liknet dette på en "needle-plane" geometri.

Tar hånd om K-verdien senere....

Driver::Time step report -- Time step #21
                                   Time  = 3.61988e-09
                                   dt    = 4.07358e-11
                                   dt restricted by 'Advection (Ito)'
                                   Emax        = 425.325 (Td)
                                   Max n/N     = 1.60416e-06 (N2+)
                                   Qplus       = 3.80625e-11
                                   Qminu       = -3.1039e-11
                                   Qsurf       = 0
                                   Qtot        = 7.02353e-12
                                   CFL (Ito)   = 0.10118
                                   CFL (CDR)   = 2.26598e-319
                                   dt/dt_relax = 0.553725
                                   #Particles  = 63 (62,014)
                                   #EB part.   = 0 (0)
                                   #Dom. part. = 0 (0)
                                   #Src. part. = 0 (0)
                                   #Min part.  = 1 (on rank = 3)
                                   #Max part.  = 44413 (on rank = 1)
                                   #Avg. part. = 5167.83
                                   #Dev. part. = 12135.9 (234.836%)
                                   Delta E(max) = 14.3566 (%)
                                   Delta E(rel) = 56.5971 (%)
                                --  2.10 percentage of time steps completed
                                --  0.00 percentage of simulation time completed
                                -- Elapsed time          : 000h 00m 33s 919ms
                                -- Last time step        : 000h 00m 01s 600ms
                                -- Wall time per/1E-09   : 000h 00m 39s 286ms
                                -- Estimated remaining   : 000h 26m 21s 311ms
                                -- Unfreed memory        : 0(MB)
                                -- Peak memory usage     : 0(MB)
                                -- Max unfreed memory    : 0(MB)
                                -- Max peak memory usage : 0(MB)
ItoKMCBackgroundEvaluator -- abort because field changed by more than specified threshold



